### PR TITLE
fix: remove deprecated port parameter from FastMCP constructor

### DIFF
--- a/weixin_search_mcp/main.py
+++ b/weixin_search_mcp/main.py
@@ -35,7 +35,7 @@ parser.add_argument("--host", type=str, default='0.0.0.0')
 
 args = parser.parse_args()
 
-mcp = FastMCP("微信公众号内容获取", port=args.port)
+mcp = FastMCP("微信公众号内容获取")
 
 @mcp.tool
 def weixin_search(query: Annotated[str, "搜索关键词"]) -> List[Dict[str, str]]:


### PR DESCRIPTION
## Problem

Running `weixin_search_mcp` with `fastmcp>=2.10.4` fails with:

```
TypeError: FastMCP() no longer accepts `port`. Pass `port` to `run_http_async()`, or set FASTMCP_PORT.
```

## Solution

Remove `port=args.port` from the `FastMCP()` constructor call in `main.py` line 38.

The port parameter is already correctly passed to `mcp.run()` in the `app()` function, so this change maintains the same functionality while fixing compatibility with newer fastmcp versions.

## Testing

Tested with `fastmcp>=2.10.4` - server starts successfully with both `--transport stdio` and `--transport http`.