### PR TITLE
chore: prepare 0.2.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install package
+        run: |
+          uv venv
+          uv pip install -e . build
+
+      - name: Verify package metadata
+        run: .venv/bin/python -c "import importlib.metadata as m; print(m.version('weixin_search_mcp'))"
+
+      - name: Smoke test module import
+        run: .venv/bin/python -c "from weixin_search_mcp.main import app; print('import ok')"
+
+      - name: Build distribution
+        run: .venv/bin/python -m build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -11,16 +12,20 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ weixin_search_mcp --transport http --port 8809 --host 0.0.0.0
 weixin_search_mcp --transport stdio
 ```
 
+通过 PyPI / `uvx` 直接运行：
+
+```bash
+uvx --from weixin-search-mcp weixin_search_mcp --transport stdio
+```
+
 ### 4. 配置MCP服务
 
 有两种方式可以配置和启动MCP服务：
@@ -62,7 +68,7 @@ weixin_search_mcp --transport stdio
     "mcpServers": {
         "weixin_search_mcp": {
             "command": "uvx",
-            "args": ["weixin_search_mcp", "--transport", "stdio"]
+            "args": ["--from", "weixin-search-mcp", "weixin_search_mcp", "--transport", "stdio"]
         }
     }
 }
@@ -73,7 +79,7 @@ weixin_search_mcp --transport stdio
 1. 启动HTTP服务：
 
 ```sh
-uvx weixin_search_mcp --transport http --port 8809
+uvx --from weixin-search-mcp weixin_search_mcp --transport http --port 8809
 ```
 
 2. 在Claude配置中添加以下内容：
@@ -95,8 +101,17 @@ uvx weixin_search_mcp --transport http --port 8809
 
 ### 微信搜索工具
 - **weixin_search**: 在搜狗微信搜索中搜索指定关键词并返回结果列表
-  - 参数: `query` - 搜索关键词
-  - 返回: 包含标题、链接、真实URL和发布时间的文章列表
+  - 参数:
+    - `query` - 搜索关键词
+    - `page` - 可选，页码，默认 `1`
+  - 返回: 包含标题、链接、真实URL、发布时间、页码的文章列表
+
+### 多页搜索工具
+- **weixin_search_all**: 自动翻页搜索多页微信公众号文章
+  - 参数:
+    - `query` - 搜索关键词
+    - `max_pages` - 可选，最大页数，默认 `10`
+  - 返回: 聚合后的多页结果列表
 
 ### 内容获取工具
 - **get_weixin_article_content**: 获取微信公众号文章的正文内容
@@ -111,6 +126,18 @@ uvx weixin_search_mcp --transport http --port 8809
 
 ```python
 results = weixin_search("人工智能")
+```
+
+按指定页搜索：
+
+```python
+results = weixin_search("人工智能", page=2)
+```
+
+自动翻页抓取：
+
+```python
+all_results = weixin_search_all("人工智能", max_pages=3)
 ```
 
 2. 获取文章内容:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weixin_search_mcp"
-version = "0.1.1"
+version = "0.2.1"
 description = "微信公众号内容搜索和获取工具"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -65,4 +65,3 @@ strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unused_ignores = true
-

--- a/weixin_search_mcp/tools/weixin_search.py
+++ b/weixin_search_mcp/tools/weixin_search.py
@@ -6,7 +6,21 @@ from lxml import html
 from urllib.parse import quote
 import time
 
-def sogou_weixin_search(query: Annotated[str, "搜索关键词"], page: int = 1) -> List[Dict[str, str]]:
+REQUEST_TIMEOUT = 15
+
+
+def _is_antispider_response(response: requests.Response) -> bool:
+    """Detect Sogou anti-spider pages that otherwise look like empty results."""
+    final_url = response.url.lower()
+    body = response.text.lower()
+    return "antispider" in final_url or "seccoderight" in body or "anti.min.css" in body
+
+
+def sogou_weixin_search(
+    query: Annotated[str, "搜索关键词"],
+    page: int = 1,
+    strict: bool = False,
+) -> List[Dict[str, str]]:
     """在搜狗微信搜索中搜索指定关键词并返回结果列表，包含真实URL
 
     Args:
@@ -34,41 +48,59 @@ def sogou_weixin_search(query: Annotated[str, "搜索关键词"], page: int = 1)
     }
 
     try:
-        response = requests.get('https://weixin.sogou.com/weixin', params=params, headers=headers)
+        response = requests.get(
+            'https://weixin.sogou.com/weixin',
+            params=params,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+        )
 
-        if response.status_code == 200:
-            tree = html.fromstring(response.text)
-            results = []
-
-            elements = tree.xpath("//a[contains(@id, 'sogou_vr_11002601_title_')]")
-            publish_time = tree.xpath(
-                "//li[contains(@id, 'sogou_vr_11002601_box_')]/div[@class='txt-box']/div[@class='s-p']/span[@class='s2']")
-
-            for element, time_elem in zip(elements, publish_time):
-                title = element.text_content().strip()
-                link = element.get('href')
-                if link and not link.startswith('http'):
-                    link = 'https://weixin.sogou.com' + link
-                
-                # 获取真实URL
-                real_url = ""
-                try:
-                    real_url = get_real_url_from_sogou(link)
-                except Exception:
-                    pass
-                
-                results.append({
-                    'title': title,
-                    'link': link,
-                    'real_url': real_url,
-                    'publish_time': time_elem.text_content().strip(),
-                    'page': str(page)  # str to match Dict[str, str] type signature
-                })
-
-            return results
-        else:
+        if response.status_code != 200:
+            if strict:
+                raise RuntimeError(f"搜狗微信搜索返回异常状态码: {response.status_code}")
             return []
+
+        if _is_antispider_response(response):
+            if strict:
+                raise RuntimeError("搜狗微信触发反爬验证，分页搜索已中止")
+            return []
+
+        tree = html.fromstring(response.text)
+        results = []
+
+        elements = tree.xpath("//a[contains(@id, 'sogou_vr_11002601_title_')]")
+        publish_time = tree.xpath(
+            "//li[contains(@id, 'sogou_vr_11002601_box_')]/div[@class='txt-box']/div[@class='s-p']/span[@class='s2']")
+
+        for element, time_elem in zip(elements, publish_time):
+            title = element.text_content().strip()
+            link = element.get('href')
+            if link and not link.startswith('http'):
+                link = 'https://weixin.sogou.com' + link
+
+            # 获取真实URL
+            real_url = ""
+            try:
+                real_url = get_real_url_from_sogou(link)
+            except Exception:
+                pass
+
+            results.append({
+                'title': title,
+                'link': link,
+                'real_url': real_url,
+                'publish_time': time_elem.text_content().strip(),
+                'page': str(page)  # str to match Dict[str, str] type signature
+            })
+
+        return results
+    except requests.RequestException as e:
+        if strict:
+            raise RuntimeError(f"请求搜狗微信搜索失败: {str(e)}") from e
+        return []
     except Exception as e:
+        if strict:
+            raise RuntimeError(f"解析搜狗微信搜索结果失败: {str(e)}") from e
         return []
 
 
@@ -83,7 +115,7 @@ def sogou_weixin_search_all(query: str, max_pages: int = 10) -> List[Dict[str, s
     """
     all_results = []
     for page in range(1, max_pages + 1):
-        results = sogou_weixin_search(query, page=page)
+        results = sogou_weixin_search(query, page=page, strict=True)
         if not results:
             break
         all_results.extend(results)
@@ -107,7 +139,10 @@ def get_real_url_from_sogou(sogou_url: str) -> str:
     }
 
     try:
-        response = requests.get(sogou_url, headers=headers)
+        response = requests.get(sogou_url, headers=headers, timeout=REQUEST_TIMEOUT)
+
+        if _is_antispider_response(response):
+            return ""
 
         script_content = response.text
         start_index = script_content.find("url += '") + len("url += '")
@@ -122,6 +157,8 @@ def get_real_url_from_sogou(sogou_url: str) -> str:
             start_index = part_end + 1
 
         full_url = ''.join(url_parts).replace("@", "")
+        if not full_url:
+            return ""
         return "https://mp." + full_url
     except Exception as e:
         return ""
@@ -155,7 +192,11 @@ def get_article_content(real_url: Annotated[str, "真实微信公众号文章链
         headers.pop('referer')
 
     try:
-        response = requests.get(real_url, headers=headers)
+        if not real_url or real_url == "https://mp.":
+            return "获取文章内容失败: 未拿到有效的微信公众号文章链接"
+
+        response = requests.get(real_url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
         tree = html.fromstring(response.text)
         content_elements = tree.xpath("//div[@id='js_content']//text()")
         cleaned_content = [text.strip() for text in content_elements if text.strip()]


### PR DESCRIPTION
## Summary
- bump package version to `0.2.1` so the next PyPI publish is not blocked by the stale `0.1.1` version metadata
- add a regular CI workflow for install/import/build smoke checks on GitHub Actions
- modernize the publish workflow and allow manual dispatch
- document explicit `uvx --from weixin-search-mcp weixin_search_mcp ...` usage for PyPI installs
- harden pagination so `weixin_search_all` no longer treats request failures / anti-spider pages as a successful end-of-results

## Why
PR #2 and PR #3 fixed FastMCP startup compatibility and added pagination, but PyPI was still stuck on `0.1.1` and the new pagination path could silently return partial data when a later page failed.

## Validation
- `uv venv`
- `uv pip install -e .`
- `python -m compileall weixin_search_mcp`
- `python -c "from weixin_search_mcp.main import app; print('IMPORT_OK')"`
- `python -m build`
- real search smoke test: `weixin_search('OpenAI', page=1/2)` and `weixin_search_all('OpenAI', max_pages=2)`
- simulated page-2 timeout to confirm `weixin_search_all(...)` now raises instead of silently truncating
